### PR TITLE
Invalid KEDA instalation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ You should see your function running locally fired correctly immediately
 
 #### 8. Install KEDA
 
-[Follow the instructions](https://keda.sh/deploy/) to deploy KEDA in your cluster.
+[Follow the instructions](https://keda.sh/docs/1.5/deploy/) to deploy KEDA in your cluster.
 
 To confirm that KEDA has successfully installed you can run the following command and should see the following CRD.
 


### PR DESCRIPTION
Hello Team,

Step no 8, the hyperlink of the instruction to be followed to install KEDA is invalid. It returns 404 Page Not Found. I have updated the URL by going to KEDA site as below "https://keda.sh/docs/1.5/deploy/"

Thanks,
Jayakumar B